### PR TITLE
Datalab 4426: Add BBC Sounds datasets and models

### DIFF
--- a/examples/bbc_sounds_recs.py
+++ b/examples/bbc_sounds_recs.py
@@ -1,0 +1,53 @@
+import os
+import json
+from itertools import groupby
+
+from reclist.datasets import BBCSoundsSampledDataset
+from reclist.recommenders.lightfm_simulator import BBCSoundsLightFMSimulatorModel
+from reclist.reclist import BBCSoundsRecList
+from reclist.utils.config import get_cache_directory, download_file, BBC_SOUNDS_PREDICTIONS, load_predictions
+
+
+def format_predictions(predictions):
+    predictions_list = []
+    for user_id, resource_ids in predictions.items():
+        user_predictions = []
+        for resource_id in resource_ids[0:12]:
+            user_predictions.append({'userId_enc': user_id, 'resourceId': resource_id})
+        predictions_list.append(user_predictions)
+    return predictions_list
+
+
+if __name__ == "__main__":
+
+    sounds_dataset = BBCSoundsSampledDataset()
+
+    model = BBCSoundsLightFMSimulatorModel()
+
+    # load predictions
+    load_from_cache = False
+    cache_dir = get_cache_directory()
+    predictions_filepath = os.path.join(cache_dir, "predictions.ndjson")
+
+    if load_from_cache:
+        print('Loading predictions from cache...')
+        with open(os.path.join(cache_dir, predictions_filepath)) as f:
+            predictions = [json.loads(line) for line in f]
+    else:
+        print('Loading predictions from: ', BBC_SOUNDS_PREDICTIONS)
+        # load from the bucket
+        predictions, _ = load_predictions(filename=BBC_SOUNDS_PREDICTIONS)
+        # and save it locally
+        if not os.path.exists(predictions_filepath):
+            download_file(BBC_SOUNDS_PREDICTIONS, predictions_filepath)
+        print('Predictions saved locally.')
+
+    formatted_predictions = format_predictions(predictions)
+
+    rec_list = BBCSoundsRecList(
+        model=model,
+        dataset=sounds_dataset,
+        y_preds=formatted_predictions
+    )
+
+    rec_list(verbose=True)

--- a/examples/sounds_recs.py
+++ b/examples/sounds_recs.py
@@ -1,0 +1,18 @@
+from reclist.datasets import BBCSoundsDataset
+from reclist.recommenders.prod2vec import BBCSoundsP2VRecModel
+from reclist.reclist import BBCSoundsSimilarItemRecList
+
+if __name__ == "__main__":
+
+    # get the MovieLens 25M dataset as a RecDataset object
+    sounds_dataset = BBCSoundsDataset()
+
+    model = BBCSoundsP2VRecModel()
+    model.train(sounds_dataset.x_train)
+
+    rec_list = BBCSoundsSimilarItemRecList(
+        model=model,
+        dataset=sounds_dataset
+    )
+
+    rec_list(verbose=True)

--- a/reclist/datasets.py
+++ b/reclist/datasets.py
@@ -4,6 +4,46 @@ import zipfile
 import os
 from reclist.abstractions import RecDataset
 from reclist.utils.config import *
+from itertools import groupby
+
+
+class BBCSoundsSampledDataset(RecDataset):
+    """
+    BBC Sounds September 2021 Dataset
+
+    Reference: https://...
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def load(self):
+        cache_dir = get_cache_directory()
+        test_filepath = os.path.join(cache_dir, "test.ndjson")
+        train_filepath = os.path.join(cache_dir, "train.ndjson")
+
+        if not os.path.exists(train_filepath) or self.force_download:
+            download_file(BBC_SOUNDS_TRAIN_GCP_URL, train_filepath)
+        if not os.path.exists(test_filepath) or self.force_download:
+            download_file(BBC_SOUNDS_TEST_GCP_URL, test_filepath)
+
+        def _format_data(filename):
+            """
+            Formats Sounds data to the expected data format from the framework
+            :param filename: str, the path of the file to format
+            :return: list of lists of dict, one for each user
+            """
+            with open(os.path.join(cache_dir, filename)) as f:
+                data = [json.loads(line) for line in f]
+
+            data_list = []
+            for user_id, records in groupby(data, key=lambda x: x['userId_enc']):
+                data_list.append(list(records))
+
+            return data_list
+
+        self._x_train = _format_data('train.ndjson')
+        self._y_test = _format_data('test.ndjson')
 
 
 class BBCSoundsDataset(RecDataset):
@@ -18,34 +58,58 @@ class BBCSoundsDataset(RecDataset):
 
     def load(self):
         cache_dir = get_cache_directory()
-        filepath = os.path.join(cache_dir, "movielens_25m.zip")
+        test_filepath = os.path.join(cache_dir, "test.ndjson")
+        train_filepath = os.path.join(cache_dir, "train.ndjson")
 
-        if not os.path.exists(filepath) or self.force_download:
-            download_with_progress(MOVIELENS_DATASET_S3_URL, filepath)
+        if not os.path.exists(train_filepath) or self.force_download:
+            download_file(BBC_SOUNDS_TRAIN_GCP_URL, train_filepath)
+        if not os.path.exists(test_filepath) or self.force_download:
+            download_file(BBC_SOUNDS_TEST_GCP_URL, test_filepath)
 
-        with tempfile.TemporaryDirectory() as temp_dir:
-            with zipfile.ZipFile(filepath, "r") as zip_file:
-                zip_file.extractall(temp_dir)
-            with open(os.path.join(temp_dir, "dataset.json")) as f:
-                data = json.load(f)
+        def _format_data(filename):
+            """
+            Formats Sounds data to the expected data format from the framework
+            :param filename: str, the path of the file to format
+            :return: list of lists of dict, one for each user
+            """
+            with open(os.path.join(cache_dir, filename)) as f:
+                data = [json.loads(line) for line in f]
 
-        self._x_train = data["x_train"]
-        self._y_train = None
-        self._x_test = data["x_test"]
-        self._y_test = data["y_test"]
-        self._catalog = self._convert_catalog_keys(data["catalog"])
+            data_list = []
+            for user_id, records in groupby(data, key=lambda x: x['userId_enc']):
+                data_list.append(list(records))
 
-    def _convert_catalog_keys(self, catalog):
-        """
-        Convert catalog keys from string to integer type
+            return data_list
 
-        JSON encodes all keys to strings, so the catalog dictionary
-        will be loaded up string representation of movie IDs.
-        """
-        converted_catalog = {}
-        for k, v in catalog.items():
-            converted_catalog[int(k)] = v
-        return converted_catalog
+        self._x_train = _format_data('train.ndjson')
+        test_data = _format_data('test.ndjson')
+
+        test_data_y = []
+        test_data_x = []
+        for records in test_data:
+            if len(records) > 1:
+
+                for rec in records:
+                    rec['label'] = 1
+
+                test_data_x.append(records[1:])
+                test_data_y.append([records[0]])
+
+        self._x_test = test_data_x
+        self._y_test = test_data_y
+        # self._catalog = self._convert_catalog_keys(data["catalog"])
+
+    # def _convert_catalog_keys(self, catalog):
+    #     """
+    #     Convert catalog keys from string to integer type
+    #
+    #     JSON encodes all keys to strings, so the catalog dictionary
+    #     will be loaded up string representation of movie IDs.
+    #     """
+    #     converted_catalog = {}
+    #     for k, v in catalog.items():
+    #         converted_catalog[int(k)] = v
+    #     return converted_catalog
 
 
 class MovieLensDataset(RecDataset):
@@ -70,11 +134,13 @@ class MovieLensDataset(RecDataset):
                 zip_file.extractall(temp_dir)
             with open(os.path.join(temp_dir, "dataset.json")) as f:
                 data = json.load(f)
-
+        print(data['catalog'])
         self._x_train = data["x_train"]
         self._y_train = None
         self._x_test = data["x_test"]
+        print(self._x_test[0:2])
         self._y_test = data["y_test"]
+        print(self._y_test[0:2])
         self._catalog = self._convert_catalog_keys(data["catalog"])
 
     def _convert_catalog_keys(self, catalog):
@@ -88,6 +154,7 @@ class MovieLensDataset(RecDataset):
         for k, v in catalog.items():
             converted_catalog[int(k)] = v
         return converted_catalog
+
 
 class CoveoDataset(RecDataset):
     """

--- a/reclist/metrics/distance_metrics.py
+++ b/reclist/metrics/distance_metrics.py
@@ -9,8 +9,9 @@ from statistics import mean
 from reclist.metrics.standard_metrics import sample_misses_at_k, sample_hits_at_k
 import numpy as np
 
+
 def error_by_cosine_distance(model, y_test, y_preds, k=3, bins=25, debug=False):
-    if not(hasattr(model.__class__, 'get_vector') and callable(getattr(model.__class__, 'get_vector'))):
+    if not (hasattr(model.__class__, 'get_vector') and callable(getattr(model.__class__, 'get_vector'))):
         error_msg = "Error : Model {} does not support retrieval of vector embeddings".format(model.__class__)
         print(error_msg)
         return error_msg
@@ -39,8 +40,9 @@ def error_by_cosine_distance(model, y_test, y_preds, k=3, bins=25, debug=False):
 
     return {'mean': np.mean(cos_distances), 'histogram': histogram}
 
+
 def distance_to_query(model, x_test, y_test, y_preds, k=3, bins=25, debug=False):
-    if not(hasattr(model.__class__, 'get_vector') and callable(getattr(model.__class__, 'get_vector'))):
+    if not (hasattr(model.__class__, 'get_vector') and callable(getattr(model.__class__, 'get_vector'))):
         error_msg = "Error : Model {} does not support retrieval of vector embeddings".format(model.__class__)
         print(error_msg)
         return error_msg
@@ -52,7 +54,7 @@ def distance_to_query(model, x_test, y_test, y_preds, k=3, bins=25, debug=False)
             vector_x = model.get_vector(m['X_TEST'][0])
             vector_y = model.get_vector(m['Y_TEST'][0])
             vectors_p = [model.get_vector(_) for _ in m['Y_PRED']]
-            c_dists =[]
+            c_dists = []
             if not vector_x or not vector_y:
                 continue
             x_to_y_cos.append(cosine(vector_x, vector_y))
@@ -91,7 +93,6 @@ def distance_to_query(model, x_test, y_test, y_preds, k=3, bins=25, debug=False)
         'raw_distances_x_to_y': x_to_y_cos,
         'raw_distances_x_to_p': x_to_p_cos,
     }
-
 
 
 def shortest_path_length():
@@ -144,7 +145,6 @@ def graph_distance_test(y_test, y_preds, product_data, k=3):
     return {'mean': mean(path_lengths), 'hist': histogram}
 
 
-
 def generic_cosine_distance(embeddings: dict,
                             type_fn,
                             y_test,
@@ -152,7 +152,6 @@ def generic_cosine_distance(embeddings: dict,
                             k=10,
                             bins=25,
                             debug=False):
-
     misses = sample_misses_at_k(y_preds, y_test, k=k, size=-1)
     cos_distances = []
     for m in misses:

--- a/reclist/reclist.py
+++ b/reclist/reclist.py
@@ -285,3 +285,149 @@ class MovieLensSimilarItemRecList(RecList):
 
     def movie_only(self, movies):
         return [[x["movieId"] for x in y] for y in movies]
+
+
+class BBCSoundsSimilarItemRecList(RecList):
+    @rec_test(test_type="stats")
+    def basic_stats(self):
+        """
+        Basic statistics on training, test and prediction data
+        """
+        from reclist.metrics.standard_metrics import statistics
+        return statistics(
+            self._x_train,
+            self._y_train,
+            self._x_test,
+            self._y_test,
+            self._y_preds
+        )
+
+    def resourceid_only(self, resource_ids):
+        return [[x["resourceId"] for x in y] for y in resource_ids]
+
+    @rec_test(test_type='HR@10')
+    def hit_rate_at_k(self):
+        """
+        Compute the rate at which the top-k predictions contain the item to be predicted
+        """
+        from reclist.metrics.standard_metrics import hit_rate_at_k
+        return hit_rate_at_k(
+            self.resourceid_only(self._y_preds),
+            self.resourceid_only(self._y_test),
+            k=10
+        )
+
+    @rec_test(test_type='hits_distribution')
+    def hits_distribution(self):
+        """
+        Compute the distribution of hit-rate across item frequency in training data
+        """
+        from reclist.metrics.hits import hits_distribution
+        return hits_distribution(
+            self.resourceid_only(self._x_train),
+            self.resourceid_only(self._x_test),
+            self.resourceid_only(self._y_test),
+            self.resourceid_only(self._y_preds),
+            k=10,
+            debug=True
+        )
+
+    @rec_test(test_type="hits_distribution_by_agerange")
+    def hits_distribution_by_agerange(self):
+        """
+        Compute the distribution of hit-rate across age ranges in testing data
+        """
+        from reclist.metrics.hits import hits_distribution_by_agerange
+        return hits_distribution_by_agerange(
+            self._y_test,
+            self._y_preds,
+            debug=True
+        )
+
+    @rec_test(test_type="hits_distribution_by_gender")
+    def hits_distribution_by_gender(self):
+        """
+        Compute the distribution of hit-rate across gender types in testing data
+        """
+        from reclist.metrics.hits import hits_distribution_by_gender
+        return hits_distribution_by_gender(
+            self._y_test,
+            self._y_preds,
+            debug=True
+        )
+
+    @rec_test(test_type='Popularity@10')
+    def popularity_bias_at_k(self):
+        """
+        Compute average frequency of occurrence across recommended items in training data
+        """
+        from reclist.metrics.standard_metrics import popularity_bias_at_k
+        return popularity_bias_at_k(self.resourceid_only(self._y_preds),
+                                    self.resourceid_only(self._x_train),
+                                    k=10)
+
+
+class BBCSoundsRecList(RecList):
+
+    def resourceid_only(self, resource_ids):
+        return [[x["resourceId"] for x in y] for y in resource_ids]
+
+    @rec_test(test_type='HR@10')
+    def hit_rate_at_k(self):
+        """
+        Compute the rate at which the top-k predictions contain the item to be predicted
+        """
+        from reclist.metrics.standard_metrics import hit_rate_at_k
+        return hit_rate_at_k(
+            self.resourceid_only(self._y_preds),
+            self.resourceid_only(self._y_test),
+            k=10
+        )
+
+    @rec_test(test_type='hits_distribution_custom')
+    def hits_distribution_custom(self):
+        """
+        Compute the distribution of hit-rate across item frequency in training data
+        """
+        from reclist.metrics.hits import hits_distribution_custom
+        return hits_distribution_custom(
+            self.resourceid_only(self._x_train),
+            self.resourceid_only(self._y_test),
+            self.resourceid_only(self._y_preds),
+            k=10,
+            debug=True
+        )
+
+    @rec_test(test_type="hits_distribution_by_agerange")
+    def hits_distribution_by_agerange(self):
+        """
+        Compute the distribution of hit-rate across age ranges in testing data
+        """
+        from reclist.metrics.hits import hits_distribution_by_agerange
+        return hits_distribution_by_agerange(
+            self._y_test,
+            self._y_preds,
+            debug=True
+        )
+
+    @rec_test(test_type="hits_distribution_by_gender")
+    def hits_distribution_by_gender(self):
+        """
+        Compute the distribution of hit-rate across gender types in testing data
+        """
+        from reclist.metrics.hits import hits_distribution_by_gender
+        return hits_distribution_by_gender(
+            self._y_test,
+            self._y_preds,
+            debug=True
+        )
+
+    @rec_test(test_type='Popularity@10')
+    def popularity_bias_at_k(self):
+        """
+        Compute average frequency of occurrence across recommended items in training data
+        """
+        from reclist.metrics.standard_metrics import popularity_bias_at_k
+        return popularity_bias_at_k(self.resourceid_only(self._y_preds),
+                                    self.resourceid_only(self._x_train),
+                                    k=10)

--- a/reclist/recommenders/lightfm_simulator.py
+++ b/reclist/recommenders/lightfm_simulator.py
@@ -1,0 +1,25 @@
+from reclist.abstractions import RecModel
+
+
+class BBCSoundsLightFMSimulatorModel(RecModel):
+    """
+    LightFM implementation for BBC Sounds Dataset
+    The model is not trained here, only predictions are being loaded directly from the specified GCP bucket.
+    """
+    model_name = "lightfm"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def predict(self, prediction_input, *args, **kwargs):
+        """
+        Predicts the top 10 similar resource IDs recommended for each user according
+        to the resource IDs that they've watched
+
+        :param prediction_input: a list of lists containing a dictionary for
+                                 each resource ID watched by that user
+        :return:
+        """
+        all_predictions = []
+
+        return all_predictions

--- a/reclist/utils/config.py
+++ b/reclist/utils/config.py
@@ -1,13 +1,43 @@
+import json
 from appdirs import *
 from pathlib import Path
 import requests
 from tqdm import tqdm
 from enum import Enum
+from google.cloud import storage
 
 COVEO_INTERACTION_DATASET_S3_URL = 'https://reclist-datasets-6d3c836d-6djh887d.s3.us-west-2.amazonaws.com/coveo_sigir.zip'
 SPOTIFY_PLAYLIST_DATASET_S3_URL = 'https://reclist-datasets-6d3c836d-6djh887d.s3.us-west-2.amazonaws.com/small_spotify_playlist.zip'
 MOVIELENS_DATASET_S3_URL = "https://reclist-datasets-6d3c836d-6djh887d.s3.us-west-2.amazonaws.com/movielens_25m.zip"
-BBC_SOUNDS_GCP_URL = "bbc-datalab-sounds-pesquet/dataset/sampled_enhanced/test/test.ndjson"
+BBC_SOUNDS_TRAIN_GCP_URL = "bbc-datalab-sounds-pesquet/dataset/sampled/train/train_1.ndjson"
+BBC_SOUNDS_TEST_GCP_URL = "bbc-datalab-sounds-pesquet/dataset/sampled/test/test.ndjson"
+BBC_SOUNDS_PREDICTIONS = "bbc-datalab-sounds-pesquet/predictions_data/xantus/2022-01-27_13:53:56.json"
+
+
+def download_file(blob_path, destination, project="datalab-user-projects-be57", bucket="parrots-projects-data"):
+    storage_client = storage.Client(project)
+    bucket = storage_client.get_bucket(bucket)
+    blob = bucket.blob(blob_path)
+    blob.download_to_filename(destination)
+
+
+def load_json_from_bucket(filename, project="datalab-user-projects-be57", bucket_name='parrots-projects-data'):
+    """ Loads json from a GCS bucket """
+    storage_client = storage.Client(project)
+    bucket = storage_client.get_bucket(bucket_name)
+    # get the blob
+    blob = bucket.get_blob(filename)
+    # load blob using json
+    file_data = json.loads(blob.download_as_string())
+    return file_data
+
+
+def load_predictions(filename, bucket_name='parrots-projects-data'):
+    json_object = load_json_from_bucket(filename, bucket_name)
+    predictions = json_object['predictions']
+    metadata = json_object['metadata']
+    return predictions, metadata
+
 
 def download_with_progress(url, destination):
     """

--- a/reclist/utils/config.py
+++ b/reclist/utils/config.py
@@ -7,7 +7,7 @@ from enum import Enum
 COVEO_INTERACTION_DATASET_S3_URL = 'https://reclist-datasets-6d3c836d-6djh887d.s3.us-west-2.amazonaws.com/coveo_sigir.zip'
 SPOTIFY_PLAYLIST_DATASET_S3_URL = 'https://reclist-datasets-6d3c836d-6djh887d.s3.us-west-2.amazonaws.com/small_spotify_playlist.zip'
 MOVIELENS_DATASET_S3_URL = "https://reclist-datasets-6d3c836d-6djh887d.s3.us-west-2.amazonaws.com/movielens_25m.zip"
-
+BBC_SOUNDS_GCP_URL = "bbc-datalab-sounds-pesquet/dataset/sampled_enhanced/test/test.ndjson"
 
 def download_with_progress(url, destination):
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,9 @@ wget==3.2
 pytest==6.2.5
 requests==2.22.0
 tqdm==4.62.3
-matplotlib==3.4.3
-numpy==1.21.2
+matplotlib==3.3.4
+numpy==1.19.5
 pathos==0.2.8
 flask==2.0.2
-networkx==2.6.3
+networkx==2.5.1
 python-Levenshtein==0.12.2


### PR DESCRIPTION
This PR adds classes and methods to load a BBC Sounds dataset from GCP;
it also adds a dummy lightFM model, which loads pre-generated predictions, and functions to generate metrics by custom (age and gender) groups).
