### PR TITLE
Update popularity bias at k

### DIFF
--- a/reclist/metrics/standard_metrics.py
+++ b/reclist/metrics/standard_metrics.py
@@ -115,7 +115,7 @@ def popularity_bias_at_k(y_preds, x_train, k=3):
     pop_map = {k:v/num_interactions for k,v in pop_map.items()}
     all_popularity = []
     for p in y_preds:
-        average_pop = sum(pop_map.get(_, 0.0) for _ in p[:k]) / len(p) if len(p) > 0 else 0
+        average_pop = sum(pop_map.get(_, 0.0) for _ in p[:k]) / len(p[:k]) if len(p) > 0 else 0
         all_popularity.append(average_pop)
     return sum(all_popularity) / len(y_preds)
 


### PR DESCRIPTION
### Description

[Line 118 in 'reclist/reclist/metrics/standard_metrics.py' ](https://github.com/jacopotagliabue/reclist/blob/48899387ff321361bd66b005bc77dcdb8752f651/reclist/metrics/standard_metrics.py#L118)(url)
The denominator should be `len(p[:k)`
``` python
def popularity_bias_at_k(y_preds, x_train, k=3):
    # estimate popularity from training data
    pop_map = collections.defaultdict(lambda : 0)
    num_interactions = 0
    for session in x_train:
        for event in session:
            pop_map[event] += 1
            num_interactions += 1
    # normalize popularity
    pop_map = {k:v/num_interactions for k,v in pop_map.items()}
    all_popularity = []
    for p in y_preds:
        average_pop = sum(pop_map.get(_, 0.0) for _ in p[:k]) / len(p) if len(p) > 0 else 0
        all_popularity.append(average_pop)
    return sum(all_popularity) / len(y_preds)
```
should not the `len(_p)` be `len(_p[:k])` ?
we will be looking till the kth slice
This is what I think should be `popularity_bias@k`
``` python

def popularity_bias_at_k(y_preds, x_train, k=3):
    # estimate popularity from training data
    pop_map = collections.defaultdict(lambda : 0)
    num_interactions = 0
    for session in x_train:
        for event in session:
            pop_map[event] += 1
            num_interactions += 1
    # normalize popularity
    pop_map = {k:v/num_interactions for k,v in pop_map.items()}
    all_popularity = []
    for p in y_preds:
        average_pop = sum(pop_map.get(_, 0.0) for _ in p[:k]) / len(p[:k]) if len(p) > 0 else 0
        all_popularity.append(average_pop)
    return sum(all_popularity) / len(y_preds)
```