### PR TITLE
Add rich lib to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ networkx==2.6.3
 python-Levenshtein==0.12.2
 pandas
 scikit-learn
+rich


### PR DESCRIPTION
In prep for the workshop, running the `EvalRSReclist` object in the KDD repo didn't run due to this missing lib in reclist.